### PR TITLE
add /api/build/<request_hash> API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,20 @@ responded JSON contains a newer version.
 | `profile`  | `netgear_wndr4300-v2` | `board_name` of `ubus call system board` |
 | `packages` | `["luci", "vim"]`     | Extra packages for the new image         |
 
+Each valid request returns a `request_hash` which can be used for future
+polling via `/api/build/<request_hash>`.
+
 ### Response `status 200`
 
 A `200` response means the image was sucessfully created. The response is JSON
 encoded containing build information.
 
-| key        | information                                 |
-| ---------- | ------------------------------------------- |
-| `bin_dir`  | relative path to created files              |
-| `buildlog` | boolean if buildlog.txt was created         |
-| `manifest` | dict of all installed packages plus version |
+| key            | information                                 |
+| -------------- | ------------------------------------------- |
+| `bin_dir`      | relative path to created files              |
+| `buildlog`     | boolean if buildlog.txt was created         |
+| `manifest`     | dict of all installed packages plus version |
+| `request_hash` | hashed request data stored by the server    |
 
     {
       "build_at": "Tue, 25 Feb 2020 08:49:48 GMT",
@@ -147,6 +151,7 @@ encoded containing build information.
         "zlib": "1.2.11-3"
       },
       "metadata_version": 1,
+      "request_hash": "5bac6cb8321f",
       "supported_devices": [
         "avm,fritzbox-4040"
       ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,30 @@ def test_api_build(client):
     assert response.json.get("request_hash") == "0222f0cd9290"
 
 
+def test_api_build_get(client):
+    client.post(
+        "/api/build",
+        json=dict(
+            version="SNAPSHOT",
+            profile="8devices_carambola",
+            packages=["test1", "test2"],
+        ),
+    )
+    response = client.get("/api/build/0222f0cd9290")
+    assert response.status == "202 ACCEPTED"
+    assert response.json.get("status") == "queued"
+    assert response.json.get("request_hash") == "0222f0cd9290"
+
+def test_api_build_get_not_found(client):
+    response = client.get("/api/build/testtesttest")
+    assert response.status == "404 NOT FOUND"
+
+
+def test_api_build_get_no_post(client):
+    response = client.post("/api/build/0222f0cd9290")
+    assert response.status == "405 METHOD NOT ALLOWED"
+
+
 def test_api_build_empty_packages(client):
     response = client.post(
         "/api/build", json=dict(version="SNAPSHOT", profile="8devices_carambola")


### PR DESCRIPTION
Now it is possible to directly request a known `request_hash`.

This should be used by all clients to run the verification function of
the server less often. Meaning a client fires the first request,
receives a `reuqest_hash` and can continue polling the hash.

Also usable for front ends to share static links of build images.

Signed-off-by: Paul Spooren <mail@aparcar.org>