### PR TITLE
parse target specific packages

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -193,7 +193,6 @@ def build(request: dict):
         job.meta["buildlog"] = True
         job.save_meta()
 
-
     if image_build.returncode:
         log.error(f"Build stdout {image_build.stdout}")
         log.error(f"Build stderr {image_build.stderr}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,8 @@ def redis():
     r = FakeStrictRedis()
     r.sadd("packages-snapshot", "test1", "test2", "test3")
     r.hmset("profiles-snapshot", {"8devices_carambola": "ramips/rt305x"})
+    r.sadd("targets-snapshot", "testtarget/testsubtarget")
+    r.hmset("profiles-snapshot", {"testprofile": "testtarget/testsubtarget"})
     yield r
 
 
@@ -45,7 +47,21 @@ def app(redis):
             "REDIS_CONN": redis,
             "STORE_PATH": test_path + "/store",
             "TESTING": True,
-            "UPSTREAM_URL": "https://cdn.openwrt.org",
+            "UPSTREAM_URL": "http://localhost:8001",
+            "VERSIONS": {
+                "metadata_version": 1,
+                "branches": [
+                    {
+                        "name": "snapshot",
+                        "enabled": True,
+                        "latest": "snapshot",
+                        "git_branch": "master",
+                        "path": "snapshots",
+                        "pubkey": "RWS1BD5w+adc3j2Hqg9+b66CvLR7NlHbsj7wjNVj0XGt/othDgIAOJS+",
+                        "updates": "dev",
+                    }
+                ],
+            },
         }
     )
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -49,7 +49,7 @@ def test_build_real(app, httpserver: HTTPServer):
         target="ath79/generic",
         store_path=app.config["STORE_PATH"],
         cache_path=app.config["CACHE_PATH"],
-        upstream_url="https://downloads.openwrt.org",
+        upstream_url="https://cdn.openwrt.org",
         version="SNAPSHOT",
         profile="tplink_tl-wdr4300-v1",
         packages=["tmux", "vim"],

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -17,4 +17,4 @@ def test_pathlib(app):
 
 
 def test_other(app):
-    assert app.config["UPSTREAM_URL"] == "https://cdn.openwrt.org"
+    assert app.config["UPSTREAM_URL"] == "http://localhost:8001"


### PR DESCRIPTION
Every target comes with specific packages like kmods, which may differ
entirely between targets. It is not enough to estimate packages by
parsing for the x86_64 arch only, but also check for specific packages.

Signed-off-by: Paul Spooren <mail@aparcar.org>