### PR TITLE
API: support commas in profile names

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -112,6 +112,12 @@ def validate_request(request_data):
             400,
         )
 
+    # The supported_devices variable on devices uses a "," instead of "_"
+    # It is stored on device as board_name and send to the server for requests
+    # To be compatible with the build system profiles replace the "," with "_"
+    # TODO upstream request to store device profile on board
+    request_data["profile"] = request_data["profile"].replace(",", "_")
+
     target = get_redis().hget(
         f"profiles-{request_data['branch']}", request_data["profile"]
     )

--- a/asu/common.py
+++ b/asu/common.py
@@ -57,7 +57,7 @@ def get_request_hash(request_data: dict) -> str:
     request_array = [
         request_data.get("distro", ""),
         request_data.get("version", ""),
-        request_data.get("profile", ""),
+        request_data.get("profile", "").replace(",", "_"),
         request_data["packages_hash"],
         str(request_data.get("packages_diff", 0)),
     ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,20 @@ def test_api_build(client):
     assert response.json.get("request_hash") == "0222f0cd9290"
 
 
+def test_api_build_comma(client):
+    response = client.post(
+        "/api/build",
+        json=dict(
+            version="SNAPSHOT",
+            profile="8devices,carambola",
+            packages=["test1", "test2"],
+        ),
+    )
+    assert response.status == "202 ACCEPTED"
+    assert response.json.get("status") == "queued"
+    assert response.json.get("request_hash") == "0222f0cd9290"
+
+
 def test_api_build_get(client):
     client.post(
         "/api/build",


### PR DESCRIPTION
Device don't store their profile but a list of supported device. These
are DeviceTree IDs and contain commas instead of underscores. To be
compatible with the ImageBuilder profiles a simple replace if "," to "_"
allows device requests from running devices.

Signed-off-by: Paul Spooren <mail@aparcar.org>