### PR TITLE
fixup: an empty packages list causes an error

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -132,7 +132,7 @@ def validate_request(request_data):
     else:
         request_data["target"] = target.decode()
 
-    if "packages" in request_data:
+    if request_data.get("packages"):
         request_data["packages"] = set(request_data["packages"]) - {"kernel", "libc"}
 
         # store request packages temporary in Redis and create a diff

--- a/asu/common.py
+++ b/asu/common.py
@@ -59,7 +59,7 @@ def get_request_hash(request_data: dict) -> str:
         request_data.get("version", ""),
         request_data.get("profile", "").replace(",", "_"),
         request_data["packages_hash"],
-        str(request_data.get("packages_diff", 0)),
+        str(request_data.get("diff_packages", False)),
     ]
     return get_str_hash(" ".join(request_array), 12)
 

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -30,10 +30,21 @@ def test_get_request_hash():
         "version": "test",
         "profile": "test",
         "package_hash": get_packages_hash(["test"]),
-        "packages_diff": "0",
     }
 
-    assert get_request_hash(request) == "006ffc934194"
+    assert get_request_hash(request) == "ce7c88df2626"
+
+
+def test_get_request_hash_diff_packages():
+    request = {
+        "distro": "test",
+        "version": "test",
+        "profile": "test",
+        "package_hash": get_packages_hash(["test"]),
+        "diff_packages": True,
+    }
+
+    assert get_request_hash(request) == "bbe753d61568"
 
 
 def test_verify_usign():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ def test_api_build(client):
     )
     assert response.status == "202 ACCEPTED"
     assert response.json.get("status") == "queued"
-    assert response.json.get("request_hash") == "0222f0cd9290"
+    assert response.json.get("request_hash") == "781846d9b15e"
 
 
 def test_api_build_comma(client):
@@ -28,7 +28,7 @@ def test_api_build_comma(client):
     )
     assert response.status == "202 ACCEPTED"
     assert response.json.get("status") == "queued"
-    assert response.json.get("request_hash") == "0222f0cd9290"
+    assert response.json.get("request_hash") == "781846d9b15e"
 
 
 def test_api_build_get(client):
@@ -40,10 +40,10 @@ def test_api_build_get(client):
             packages=["test1", "test2"],
         ),
     )
-    response = client.get("/api/build/0222f0cd9290")
+    response = client.get("/api/build/781846d9b15e")
     assert response.status == "202 ACCEPTED"
     assert response.json.get("status") == "queued"
-    assert response.json.get("request_hash") == "0222f0cd9290"
+    assert response.json.get("request_hash") == "781846d9b15e"
 
 
 def test_api_build_get_not_found(client):
@@ -56,13 +56,34 @@ def test_api_build_get_no_post(client):
     assert response.status == "405 METHOD NOT ALLOWED"
 
 
-def test_api_build_empty_packages(client):
+def test_api_build_empty_packages_list(client):
+    response = client.post(
+        "/api/build",
+        json=dict(version="SNAPSHOT", profile="8devices_carambola", packages=[]),
+    )
+    assert response.status == "202 ACCEPTED"
+    assert response.json.get("status") == "queued"
+    assert response.json.get("request_hash") == "66af84b3e079"
+
+
+def test_api_build_withouth_packages_list(client):
     response = client.post(
         "/api/build", json=dict(version="SNAPSHOT", profile="8devices_carambola")
     )
     assert response.status == "202 ACCEPTED"
     assert response.json.get("status") == "queued"
-    assert response.json.get("request_hash") == "5bac6cb8321f"
+    assert response.json.get("request_hash") == "66af84b3e079"
+
+
+def test_api_build_bad_packages_str(client):
+    response = client.post(
+        "/api/build",
+        json=dict(
+            version="SNAPSHOT", profile="8devices_carambola", packages="testpackage"
+        ),
+    )
+    assert response.status == "422 UNPROCESSABLE ENTITY"
+    assert response.json.get("status") == "bad_packages"
 
 
 def test_api_build_empty_request(client):


### PR DESCRIPTION
Diffing an empty packages list does not make any sense and resulted in
an error with Redis pipeline. Now just ignore those empty packages
lists.

Signed-off-by: Paul Spooren <mail@aparcar.org>