### PR TITLE
fixup: set job timeout to 5 minutes

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -275,6 +275,7 @@ def api_build():
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,
+            timeout="5m",
         )
 
     return return_job(job)


### PR DESCRIPTION
Slow downloads and slow extracting may exceed the 3 minute default
timeout or python rq.

Signed-off-by: Paul Spooren <mail@aparcar.org>