### PR TITLE
fixup: replace timeout with job_timeout

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -275,7 +275,7 @@ def api_build():
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,
-            timeout="5m",
+            job_timeout="5m",
         )
 
     return return_job(job)


### PR DESCRIPTION
Python RQ uses different variable names for the Job() class and the
enqueue function.

Signed-off-by: Paul Spooren <mail@aparcar.org>