### PR TITLE
Do not try to merge profiles when none were found

### DIFF
--- a/asu/janitor.py
+++ b/asu/janitor.py
@@ -193,6 +193,11 @@ def get_json_files(version: dict):
 
     pool = Pool(20)
     profiles = pool.map(download_profile, files)
+    if len(profiles) == 0:
+        current_app.logger.warn(
+            f"No profile JSON file found for version {version['name']}"
+        )
+        return
     current_app.logger.info("Done downloading profile JSON files")
     merge_profiles(version, profiles)
 


### PR DESCRIPTION
I've tried to test ASU with 19.07.2 release (only to find [releases were not yet supported](https://github.com/aparcar/asu/issues/243#issuecomment-605383560) as there are no [JSON files](http://downloads.openwrt.org/releases/19.07.2/targets/?json)) by enabling it in my `~/.local/var/asu-instance/config.py` file:

```py
# disable test and debug features
TESTING=False,
DEBUG=True,

# supported versions
VERSIONS={
    "metadata_version": 1,
    "branches": [
        {
            "name": "snapshot",
            "enabled": True,
            "latest": "snapshot",
            "git_branch": "master",
            "path": "snapshots",
            "pubkey": "RWS1BD5w+adc3j2Hqg9+b66CvLR7NlHbsj7wjNVj0XGt/othDgIAOJS+",
            "updates": "dev",
        },
        {
            "name": "19.07",
            "enabled": True,
            "eol": "2020-01-01",
            "latest": "19.07.2",
            "git_branch": "openwrt-19.07",
            "path": "releases/19.07.2",
            "pubkey": "RWT5S53W/rrJY9BiIod3JF04AZ/eU1xDpVOb+rjZzAQBEcoETGx8BXEK",
            "release_date": "2020-01-31",
            "updates": "bugs",
        },
        {
            "name": "18.06",
            "enabled": False,
            "eol": "2019-01-01",
            "latest": "18.06.7",
            "git_branch": "openwrt-18.06",
            "path": "releases/18.06.7",
            "pubkey": "RWT5S53W/rrJY9BiIod3JF04AZ/eU1xDpVOb+rjZzAQBEcoETGx8BXEK",
            "release_date": "2019-01-31",
            "updates": "security",
        },
    ],
}
```

But `flask janitor init` would error with:

```
# flask janitor init
...
[2020-03-29 09:38:43,484] INFO in janitor: Setup 19.07                                                                                                                                   
[2020-03-29 09:38:43,816] INFO in janitor: Done downloading profile JSON files                                                                                                           
Traceback (most recent call last):                                                                                                                                                       
  File "/home/patrick/.local/bin/flask", line 10, in <module>                                                                                                                            
    sys.exit(main())                                                                                                                                                                     
  File "/home/patrick/.local/lib/python3.7/site-packages/flask/cli.py", line 966, in main                                                                                                
    cli.main(prog_name="python -m flask" if as_module else None)                                                                                                                         
  File "/home/patrick/.local/lib/python3.7/site-packages/flask/cli.py", line 586, in main   
    return super(FlaskGroup, self).main(*args, **kwargs)                                   
  File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main                                                                                                                 
    rv = self.invoke(ctx)                                                                   
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke                                                                                                              
    return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                              
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke                                                                                                              
    return _process_result(sub_ctx.command.invoke(sub_ctx))                                 
  File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke                                                                                                               
    return ctx.invoke(self.callback, **ctx.params)                                          
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke                                                                                                               
    return callback(*args, **kwargs)                                                                                                                                                     
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 17, in new_func                                                                                                        
    return f(get_current_context(), *args, **kwargs)                                                                                                                                     
  File "/home/patrick/.local/lib/python3.7/site-packages/flask/cli.py", line 426, in decorator                                                                                           
    return __ctx.invoke(f, *args, **kwargs)                                                                                                                                              
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke                  
    return callback(*args, **kwargs)                                                                                                                                                     
  File "/home/patrick/.local/lib/python3.7/site-packages/asu/janitor.py", line 215, in init
    get_json_files(version)                                                                                                                                                              
  File "/home/patrick/.local/lib/python3.7/site-packages/asu/janitor.py", line 197, in get_json_files
    merge_profiles(version, profiles)                                                                                                                                                    
  File "/home/patrick/.local/lib/python3.7/site-packages/asu/janitor.py", line 144, in merge_profiles
    r.sadd(f"targets-{version['name']}", *targets)                          
  File "/home/patrick/.local/lib/python3.7/site-packages/redis/client.py", line 2208, in sadd
    return self.execute_command('SADD', name, *values)                                                                                                                                   
  File "/home/patrick/.local/lib/python3.7/site-packages/redis/client.py", line 878, in execute_command
    return self.parse_response(conn, command_name, **options)                               
  File "/home/patrick/.local/lib/python3.7/site-packages/redis/client.py", line 892, in parse_response
    response = connection.read_response()                                                   
  File "/home/patrick/.local/lib/python3.7/site-packages/redis/connection.py", line 752, in read_response
    raise response                                                                          
redis.exceptions.ResponseError: wrong number of arguments for 'sadd' command
```

This PR avoids to error when a version has no profile:

```
# flask janitor init
...
[2020-03-29 11:13:12,551] INFO in janitor: Setup 19.07
[2020-03-29 11:13:12,849] WARNING in janitor: No profile JSON file found for version 19.07
...
```