### PR TITLE
release: v0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(join(base_path, "requirements.txt")) as req_file:
 
 setup(
     name="asu",
-    version="0.4.0",
+    version="0.4.1",
     url="https://github.com/aparcar/asu",
     maintainer="Paul Spooren",
     maintainer_email="mail@aparcar.org",


### PR DESCRIPTION
Patrick Decat (2):
      Do not try to merge profiles when none were found
      Add path information to 19.07 and 18.06 release versions

Paul Spooren (5):
      fixup: set job timeout to 5 minutes
      fixup: Correct sig_file_headers debug print
      fixup: replace timeout with job_timeout
      build: adapt to new profiles.json
      fixup: use new OpenWrt CDN

Signed-off-by: Paul Spooren <mail@aparcar.org>