### PR TITLE
fixup: use new OpenWrt CDN

### DIFF
--- a/asu/__init__.py
+++ b/asu/__init__.py
@@ -22,7 +22,7 @@ def create_app(test_config: dict = None) -> Flask:
         REDIS_CONN=Redis(),
         TESTING=False,
         DEBUG=False,
-        UPSTREAM_URL="https://downloads.openwrt.org",
+        UPSTREAM_URL="https://downloads.cdn.openwrt.org",
         VERSIONS={
             "metadata_version": 1,
             "branches": [

--- a/misc/config.py
+++ b/misc/config.py
@@ -6,7 +6,7 @@ TESTING=False,
 DEBUG=False,
 
 # where to find the ImageBuildes
-UPSTREAM_URL="https://cdn.openwrt.org",
+UPSTREAM_URL="https://downloads.cdn.openwrt.org",
 
 # supported versions
 VERSIONS={

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -132,7 +132,7 @@ def test_build_real(app, httpserver: HTTPServer):
         target="ath79/generic",
         store_path=app.config["STORE_PATH"],
         cache_path=app.config["CACHE_PATH"],
-        upstream_url="https://cdn.openwrt.org",
+        upstream_url="https://downloads.cdn.openwrt.org",
         version="SNAPSHOT",
         profile="tplink_tl-wdr4300-v1",
         packages={"tmux", "vim"},

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -95,7 +95,7 @@ def test_get_json_files(app, httpserver: HTTPServer, redis):
 
 
 def test_get_packages_arch_real(app, httpserver: HTTPServer, redis):
-    app.config["UPSTREAM_URL"] = "https://cdn.openwrt.org"
+    app.config["UPSTREAM_URL"] = "https://downloads.cdn.openwrt.org"
     version = app.config["VERSIONS"]["branches"][0]
     with app.app_context():
         get_packages_arch(version, sources=["base", "luci"])
@@ -105,7 +105,7 @@ def test_get_packages_arch_real(app, httpserver: HTTPServer, redis):
 @pytest.mark.slow
 @pytest.mark.skip
 def test_get_json_files_real(app, httpserver: HTTPServer, redis):
-    app.config["UPSTREAM_URL"] = "https://cdn.openwrt.org"
+    app.config["UPSTREAM_URL"] = "https://downloads.cdn.openwrt.org"
     version = app.config["VERSIONS"]["branches"][0]
     with app.app_context():
         get_json_files(version)


### PR DESCRIPTION
The OpenWrt CDN moved to downloads.cdn.openwrt.org

Signed-off-by: Paul Spooren <mail@aparcar.org>