### PR TITLE
Add ucert support

### DIFF
--- a/asu/__init__.py
+++ b/asu/__init__.py
@@ -18,6 +18,7 @@ def create_app(test_config: dict = None) -> Flask:
     """
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_mapping(
+        CA_PUBKEY=None,
         STORE_PATH=app.instance_path + "/public/store",
         JSON_PATH=app.instance_path + "/public/json",
         CACHE_PATH=app.instance_path + "/cache/",

--- a/asu/api.py
+++ b/asu/api.py
@@ -300,6 +300,7 @@ def api_build():
         req["store_path"] = current_app.config["STORE_PATH"]
         req["cache_path"] = current_app.config["CACHE_PATH"]
         req["upstream_url"] = current_app.config["UPSTREAM_URL"]
+        req["ca_pubkey"] = current_app.config["CA_PUBKEY"]
         req["branch_data"] = get_branches()[req["branch"]]
 
         job = get_queue().enqueue(

--- a/asu/common.py
+++ b/asu/common.py
@@ -95,6 +95,19 @@ def get_packages_hash(packages: list) -> str:
     return get_str_hash(" ".join(sorted(list(set(packages)))), 12)
 
 
+def fingerprint_pubkey_usign(pubkey: str) -> str:
+    """Return fingerprint of signify/usign public key
+
+    Args:
+        pubkey (str): signify/usign public key
+
+    Returns:
+        str: string containing the fingerprint
+    """
+    keynum = base64.b64decode(pubkey.splitlines()[-1])[2:10]
+    return "".join(format(x, "02x") for x in keynum)
+
+
 def verify_usign(sig_file: Path, msg_file: Path, pub_key: str) -> bool:
     """Verify a signify/usign signature
 

--- a/misc/config.py
+++ b/misc/config.py
@@ -5,6 +5,8 @@
 TESTING = False
 DEBUG = True
 
+CA_PUBKEY = "RWSGJBpwejDLf4OApA5SOavh0GBlBFY9FhqxnivUQHpi0/t0QRI98LPW"
+
 # where to find the ImageBuildes
 UPSTREAM_URL = "https://downloads.cdn.openwrt.org"
 

--- a/misc/config.py
+++ b/misc/config.py
@@ -25,9 +25,7 @@ BRANCHES = [
             "lime-packages": "https://feed.libremesh.org/master",
             "lime-profiles": "https://feed.libremesh.org/profiles",
         },
-        "extra_keys": {
-            "a71b3c8285abd28b": "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"
-        },
+        "extra_keys": ["RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"],
         "targets": {
             "apm821xx/nand": "powerpc_464fp",
             "apm821xx/sata": "powerpc_464fp",
@@ -114,9 +112,7 @@ BRANCHES = [
             "lime-packages": "https://feed.libremesh.org/master",
             "lime-profiles": "https://feed.libremesh.org/profiles",
         },
-        "extra_keys": {
-            "a71b3c8285abd28b": "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"
-        },
+        "extra_keys": ["RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8"],
         "targets": {
             "apm821xx/nand": "powerpc_464fp",
             "apm821xx/sata": "powerpc_464fp",


### PR DESCRIPTION
This allows to use define a CA_PUBKEY which is added to running devices. As a consequence a secret upgrade path is possible because OpenWrts `sysupgrade` can check ucert signatures.