### PR TITLE
add OpenWrt 21.02.0-rc1 support

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -145,11 +145,11 @@ def validate_request(req):
 
     req["version"] = req["version"]
 
-    if req["version"].count("-"):
+    if req["version"].endswith("-SNAPSHOT"):
         # e.g. 21.02-snapshot
         req["branch"] = req["version"].rsplit("-", maxsplit=1)[0]
     else:
-        # e.g. snapshot or 19.07.7
+        # e.g. snapshot, 21.02.0-rc1 or 19.07.7
         req["branch"] = req["version"].rsplit(".", maxsplit=1)[0]
 
     if req["branch"] not in get_branches().keys():

--- a/misc/config.py
+++ b/misc/config.py
@@ -112,7 +112,7 @@ BRANCHES = [
         "name": "21.02",
         "enabled": True,
         "snapshot": True,
-        "versions": ["21.02-SNAPSHOT"],
+        "versions": ["21.02.0-rc1", "21.02-SNAPSHOT"],
         "git_branch": "openwrt-21.02",
         "path": "releases/{version}",
         "path_packages": "releases/packages-{branch}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import tempfile
 
 from fakeredis import FakeStrictRedis
 
-from asu import create_app
+from asu.asu import create_app
 
 
 def pytest_addoption(parser):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,4 +1,4 @@
-from asu import create_app
+from asu.asu import create_app
 from pathlib import PosixPath
 
 


### PR DESCRIPTION
Add version to config.py and change branch detection logic to support
rc suffixes.

Signed-off-by: Paul Spooren <mail@aparcar.org>