### PR TITLE
api: require target in build request

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ variable in the configuration, an example is available in `./misc/config.py`.
 
 | key             | value                 | information                              |
 | --------------- | --------------------- | ---------------------------------------- |
-| `version`       | `SNAPSHOT`            | installed version                        |
+| `version`       | `SNAPSHOT`            | Requested version                        |
+| `target`        | `ath79/nand`          | Requested target                         |
 | `profile`       | `netgear_wndr4300-v2` | `board_name` of `ubus call system board` |
 | `packages`      | `["luci", "vim"]`     | Extra packages for the new image         |
 | `diff_packages` | `true`                | Install list of `packages` additionally to default packages or excklusively |

--- a/asu/janitor.py
+++ b/asu/janitor.py
@@ -233,7 +233,7 @@ def update_target_profiles(branch: dict, version: str, target: str):
     for profile, data in profiles.items():
         for supported in data.get("supported_devices", []):
             r.hset(f"mapping-{branch['name']}-{version}", supported, profile)
-        r.hset(f"profiles-{branch['name']}-{version}", profile, target)
+        r.sadd(f"profiles-{branch['name']}-{version}-{target}", profile)
         profile_path = (
             current_app.config["JSON_PATH"]
             / version_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,14 +33,12 @@ def redis():
     r.sadd(
         "packages-SNAPSHOT-SNAPSHOT-testtarget/testsubtarget", "test1", "test2", "test3"
     )
-    r.hset(
-        "profiles-SNAPSHOT-SNAPSHOT",
-        mapping={"testprofile": "testtarget/testsubtarget"},
-    )
+    r.sadd("profiles-SNAPSHOT-SNAPSHOT-testtarget/testsubtarget", "testprofile")
     r.hset(
         "mapping-SNAPSHOT-SNAPSHOT", mapping={"testvendor,testprofile": "testprofile"}
     )
     r.sadd("targets-SNAPSHOT", "testtarget/testsubtarget")
+    r.sadd("targets-21.02", "testtarget/testsubtarget")
     yield r
 
 
@@ -73,7 +71,7 @@ def app(redis):
                     "name": "21.02",
                     "enabled": True,
                     "snapshot": True,
-                    "versions": ["21.02-SNAPSHOT"],
+                    "versions": ["21.02.0-rc1", "21.02-SNAPSHOT"],
                     "git_branch": "openwrt-21.02",
                     "path": "releases/{version}",
                     "path_packages": "releases/packages-{branch}",


### PR DESCRIPTION
While most profiles are unique and there the used target is
"predictable", especially x86 profile names all use "generic". Since it
can't be guaranteed that profiles between targets are unique, require a
specific target.

Signed-off-by: Paul Spooren <mail@aparcar.org>